### PR TITLE
Expand `home` before passing it on

### DIFF
--- a/hyde.el
+++ b/hyde.el
@@ -70,6 +70,13 @@
   :type 'string
   :group 'hyde)
 
+(defcustom hyde/use-octopress
+  nil
+  "Changes some behaviors when using Octopress"
+  :type 'boolean
+  :group 'hyde)
+
+
 ;; Faces and font-locking
 (defface hyde-header-face
   '(
@@ -272,6 +279,9 @@ user"
       (insert "---\n")
       (insert "layout: post\n")
       (insert (format "title: \"%s\"\n" title))
+      (when hyde/use-octopress
+        (insert (format "date: %s\ncomments: true\ncategories:\n"
+                        (format-time-string "%Y-%m-%d %H:%M"))))
       (insert "---\n\n")
       (save-buffer))
     (hyde/hyde-add-file post-file-name)


### PR DESCRIPTION
I'm not sure if it has something to do with my setup, but the version with `expand-file-name` works a lot better for me.
