### PR TITLE
Set default-directory to the Hyde home dir.

### DIFF
--- a/hyde.el
+++ b/hyde.el
@@ -361,7 +361,8 @@ user"
   (use-local-map hyde-mode-map)
   (set (make-local-variable 'font-lock-defaults) '(hyde-font-lock-keywords))
   (setq major-mode 'hyde/hyde-mode
-	mode-name "Hyde")
+	mode-name "Hyde"
+        default-directory home)
   (hyde/read-config hyde-home)
   (hyde/load-posts)
   (hl-line-mode t)


### PR DESCRIPTION
With this patch, the working directory of the Hyde buffer is set to the Hyde home directory, so find-file or similar commands start from that directory, analogous to how Magit or similar modes work.
