### PR TITLE
Find Hyde root automatically using vc-find-root.

### DIFF
--- a/hyde.el
+++ b/hyde.el
@@ -505,14 +505,20 @@ user"
 
 
 ;; Entry point
-(defun hyde (home)
+(defun hyde (&optional home)
   "Enters hyde mode"
-  (interactive "DBlog : ")
-  (let (
-	(hyde-buffer (concat "*Hyde : " home "*"))
-	)
-    (switch-to-buffer (get-buffer-create hyde-buffer)))
-  (hyde/hyde-mode home))
+  (interactive)
+  (let* (
+         (jekyll-root (or home
+                          (hyde/ask-for-jekyll-root)))
+         (hyde-buffer (concat "*Hyde:" jekyll-root "*"))
+         )
+    (switch-to-buffer (get-buffer-create hyde-buffer))
+    (hyde/hyde-mode jekyll-root)))
+
+(defun hyde/ask-for-jekyll-root ()
+  (or (vc-find-root (buffer-file-name) "_config.yml")
+      (read-directory-name "Jekyll root: ")))
 
 (provide 'hyde)
 


### PR DESCRIPTION
This patch makes the "home" argument to the "hyde" entry point function completely optional. If provided, it uses that argument's value, if not provided, it uses the built-in "vc-find-root" to attempt to find the Jekyll root by looking for "_config.yml," which all Jekyll sites have. If it fails to find that file, it then prompts the user for a directory.

I also modified the prompt text from "Blog : " to "Jekyll root: ", but of course feel free to change it back; the colon spacing in this patch is consistent with other Emacs packages and Jekyll sites are not *necessarily* blogs.