### PR TITLE
Add explicit require cl

### DIFF
--- a/hyde.el
+++ b/hyde.el
@@ -23,6 +23,7 @@
 (require 'hyde-git)
 (require 'hyde-md)
 (require 'easymenu)
+(require 'cl)
 
 ;; Constants for internal use
 (defconst hyde/hyde-version "0.3a"


### PR DESCRIPTION
There was an error in hyde/list-format-posts function
failing because of using map function, which is defined
on cl package that wasn't required
